### PR TITLE
Fix SyntaxWarning

### DIFF
--- a/cargo2ports.py
+++ b/cargo2ports.py
@@ -91,7 +91,7 @@ def get_packages_from_metadata(text):
     metadata_lines = match.groups()[0].split("\n")
 
     for line in metadata_lines:
-        tokens = re.split("\s+", line)
+        tokens = re.split(r"\s+", line)
         if len(tokens) >= 6:
             package = dict()
 
@@ -176,7 +176,7 @@ def is_v1_lockfile(text):
     Return True if the given file contents are a V1 Cargo.lock file, False
     otherwise.
     """
-    return True if re.search("^\[metadata\]", text, re.MULTILINE) else False
+    return True if re.search(r"^\[metadata\]", text, re.MULTILINE) else False
 
 
 def main():


### PR DESCRIPTION
Hello

I get `SyntaxWarning` on python 3.12 & 3.14:
```
cargo2ports/cargo2ports.py:94: SyntaxWarning: invalid escape sequence '\s'
  tokens = re.split("\s+", line)
cargo2ports/cargo2ports.py:179: SyntaxWarning: invalid escape sequence '\['
  return True if re.search("^\[metadata\]", text, re.MULTILINE) else False
cargo.crates \
    addr2line                       0.24.2  dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1 \
```

Converting to raw strings fixes that.